### PR TITLE
[fix] 엑세스토큰 재발급 로직 오류 수정 및 토큰 유효시간 변경

### DIFF
--- a/ChargeControlBackend/src/main/java/com/ChargeControl/www/Backend/api/member/domain/Member.java
+++ b/ChargeControlBackend/src/main/java/com/ChargeControl/www/Backend/api/member/domain/Member.java
@@ -85,4 +85,8 @@ public class Member extends BaseTimeEntity implements UserDetails {
         return this.email;
     }
 
+    public Role getRole() {
+        return role;
+    }
+
 }

--- a/ChargeControlBackend/src/main/java/com/ChargeControl/www/Backend/api/member/dto/MemberResponse.java
+++ b/ChargeControlBackend/src/main/java/com/ChargeControl/www/Backend/api/member/dto/MemberResponse.java
@@ -1,0 +1,19 @@
+package com.ChargeControl.www.Backend.api.member.dto;
+
+import com.ChargeControl.www.Backend.api.member.domain.Role;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MemberResponse {
+
+    private String name;
+    private String carNumber;
+    private String email;
+    private Role role;
+}

--- a/ChargeControlBackend/src/main/java/com/ChargeControl/www/Backend/api/member/service/CustomUserDetailsService.java
+++ b/ChargeControlBackend/src/main/java/com/ChargeControl/www/Backend/api/member/service/CustomUserDetailsService.java
@@ -6,10 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Service;
-
-import java.util.Collections;
 
 @Service
 public class CustomUserDetailsService implements UserDetailsService {
@@ -25,10 +22,6 @@ public class CustomUserDetailsService implements UserDetailsService {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("No user found with email: " + email));
 
-        return new org.springframework.security.core.userdetails.User(
-                member.getEmail(),
-                member.getPassword(),
-                Collections.singletonList(new SimpleGrantedAuthority(member.getRole().name()))
-        );
+        return member;
     }
 }

--- a/ChargeControlBackend/src/main/java/com/ChargeControl/www/Backend/api/member/service/Impl/EmailService.java
+++ b/ChargeControlBackend/src/main/java/com/ChargeControl/www/Backend/api/member/service/Impl/EmailService.java
@@ -39,7 +39,7 @@ public class EmailService {
         SimpleMailMessage mailMessage = new SimpleMailMessage();
         mailMessage.setFrom(serviceEmail);
         mailMessage.setTo(email);
-        mailMessage.setSubject("Email Verification For " + email);
+        mailMessage.setSubject("ChargeControl 회원가입 인증코드 입니다.");
         mailMessage.setText(verification.generateCodeMessage());
         mailSender.send(mailMessage);
     }

--- a/ChargeControlBackend/src/main/java/com/ChargeControl/www/Backend/api/member/service/Impl/MemberServiceImpl.java
+++ b/ChargeControlBackend/src/main/java/com/ChargeControl/www/Backend/api/member/service/Impl/MemberServiceImpl.java
@@ -34,7 +34,7 @@ public class MemberServiceImpl implements MemberService {
     @Value("${jwt.secret}")
     private String secretKey;
 
-    private Long accessTokenValidityMs = 900_000L; // 1 hour for accessToken
+    private Long accessTokenValidityMs = 900_000L; // 엑세스토큰 15분 유효시간
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
@@ -91,7 +91,7 @@ public class MemberServiceImpl implements MemberService {
                 .orElseThrow(() -> new IllegalArgumentException("No user found with email: " + email));
 
         String newRefreshToken = UUID.randomUUID().toString();
-        Instant newExpiryDate = Instant.now().plusMillis(7 * 24 * 60 * 60 * 1000);
+        Instant newExpiryDate = Instant.now().plusMillis(7 * 24 * 60 * 60 * 1000); // 리프레시토큰 일주일 유효시간
 
         member.updateRefreshToken(newRefreshToken, newExpiryDate);
 

--- a/ChargeControlBackend/src/main/java/com/ChargeControl/www/Backend/api/member/service/Impl/MemberServiceImpl.java
+++ b/ChargeControlBackend/src/main/java/com/ChargeControl/www/Backend/api/member/service/Impl/MemberServiceImpl.java
@@ -34,7 +34,7 @@ public class MemberServiceImpl implements MemberService {
     @Value("${jwt.secret}")
     private String secretKey;
 
-    private Long accessTokenValidityMs = 3600_000L; // 1 hour for accessToken
+    private Long accessTokenValidityMs = 900_000L; // 1 hour for accessToken
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
@@ -91,25 +91,24 @@ public class MemberServiceImpl implements MemberService {
                 .orElseThrow(() -> new IllegalArgumentException("No user found with email: " + email));
 
         String newRefreshToken = UUID.randomUUID().toString();
-        Instant newExpiryDate = Instant.now().plusMillis(600000);
+        Instant newExpiryDate = Instant.now().plusMillis(7 * 24 * 60 * 60 * 1000);
 
         member.updateRefreshToken(newRefreshToken, newExpiryDate);
 
         return memberRepository.save(member);
     }
 
-    public Optional<Member> findByToken(String token){
-        return memberRepository.findByRefreshToken(token);
-    }
-
-    @Override
     public void verifyRefreshTokenExpiration(String token) {
         Member member = findByToken(token)
-                .orElseThrow(() -> new RuntimeException("Invalid refresh token."));
+                .orElseThrow(() -> new BadRequestException("유효한 RefreshToken이 아닙니다."));
 
         if (member.getExpiryDate().isBefore(Instant.now())) {
-            throw new RuntimeException("Refresh token expired. Please log in again.");
+            throw new BadRequestException("인증이 만료되었습니다. 재로그인 하십시오.");
         }
+    }
+
+    public Optional<Member> findByToken(String token) {
+        return memberRepository.findByRefreshToken(token);
     }
 
 }

--- a/ChargeControlBackend/src/main/java/com/ChargeControl/www/Backend/common/config/SecurityConfig.java
+++ b/ChargeControlBackend/src/main/java/com/ChargeControl/www/Backend/common/config/SecurityConfig.java
@@ -2,9 +2,9 @@ package com.ChargeControl.www.Backend.common.config;
 
 import com.ChargeControl.www.Backend.api.member.jwt.JwtFilter;
 import com.ChargeControl.www.Backend.api.member.service.CustomUserDetailsService;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -39,13 +39,17 @@ public class SecurityConfig {
                 .csrf().disable()
                 .cors().and()
                 .authorizeHttpRequests(authz -> authz
-                        .requestMatchers("/api/v1/login", "/api/v1/join", "/api/v1/verify-email", "/api/v1/verification-code", "/h2-console/**").permitAll()
+                        .requestMatchers("/api/v1/login", "/api/v1/join", "/api/v1/verify-email", "/api/v1/verification-code", "api/v1/refreshToken", "/h2-console/**").permitAll()
                         .anyRequest().authenticated())
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .headers().frameOptions().sameOrigin()
                 .and()
-                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling()
+                .authenticationEntryPoint((request, response, authException) -> {
+                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+                });
 
         http.authenticationProvider(authenticationProvider());
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #8

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
엑세스토큰 재발급 로직 에서 예외처리 발생 전 기능 수행으로 발생되는 문제 해결 및 엑세스, 리프레시 토큰 유효시간을 각각 15분 일주일로 변경하였습니다.
스프링시큐리티 에서 미 인증된 엔드포인트의 경우 403 Forbidden 이 아닌 401 UnAuth 로 리턴되도록 수정하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
<img width="883" alt="스크린샷 2024-05-12 오후 8 27 12" src="https://github.com/Charge-Control/Backend/assets/12209059/9606ec60-7b64-4c47-9436-7327c6ceb24e">
